### PR TITLE
Remove error spans on reset

### DIFF
--- a/jquery.validate.unobtrusive.js
+++ b/jquery.validate.unobtrusive.js
@@ -108,6 +108,7 @@
             .removeData("unobtrusiveContainer")
             .find(">*")  // If we were using valmsg-replace, get the underlying error
                 .removeData("unobtrusiveContainer");
+        $form.find("span").empty();
     }
 
     function validationInfo(form) {


### PR DESCRIPTION
This should make unobtrusive error messages actually hide when `$("form").trigger("reset")` is run.