### PR TITLE
Added flags parameter to regexp validation rule

### DIFF
--- a/src/jquery.validate.unobtrusive.js
+++ b/src/jquery.validate.unobtrusive.js
@@ -342,7 +342,7 @@
             return true;
         }
 
-        match = new RegExp(params).exec(value);
+        match = new RegExp(params.pattern, params.flags).exec(value);
         return (match && (match.index === 0) && (match[0].length === value.length));
     });
 
@@ -365,7 +365,17 @@
         adapters.addSingleVal("extension", "extension", "accept");
     }
 
-    adapters.addSingleVal("regex", "pattern");
+    adapters.add("regex", ["pattern", "flags"], function (options) {
+        if (options.params.pattern) {
+            var params = {
+                pattern: options.params.pattern
+            };
+            if (options.params.flags) {
+                params["flags"] = options.params.flags;
+            }
+            setValidationValues(options, "regex", params);
+        }
+    });
     adapters.addBool("creditcard").addBool("date").addBool("digits").addBool("email").addBool("number").addBool("url");
     adapters.addMinMax("length", "minlength", "maxlength", "rangelength").addMinMax("range", "min", "max", "range");
     adapters.addMinMax("minlength", "minlength").addMinMax("maxlength", "minlength", "maxlength");


### PR DESCRIPTION
I added a new option to the regex validation to support regex options. I needed to add the case insensitive option. 

The new options enables the developer to pass in RegExp options. For example:

```
data-val-regex="Please start your sentence with foo or end it with bar!" 
data-val-regex-pattern="^foo|bar$"
data-val-regex-flags="i" />
```

If no flags are specified, the code behaves like before (the flags parameter becomes undefined)
