### PR TITLE
onReset empty

### DIFF
--- a/src/jquery.validate.unobtrusive.js
+++ b/src/jquery.validate.unobtrusive.js
@@ -117,8 +117,7 @@
             .addClass("field-validation-valid")
             .removeClass("field-validation-error")
             .removeData("unobtrusiveContainer")
-            .find(">*")  // If we were using valmsg-replace, get the underlying error
-            .removeData("unobtrusiveContainer");
+            .empty();
     }
 
     function validationInfo(form) {

--- a/src/jquery.validate.unobtrusive.js
+++ b/src/jquery.validate.unobtrusive.js
@@ -112,7 +112,8 @@
 
         $form.find(".validation-summary-errors")
             .addClass("validation-summary-valid")
-            .removeClass("validation-summary-errors");
+            .removeClass("validation-summary-errors")
+            .find("ul").empty();
         $form.find(".field-validation-error")
             .addClass("field-validation-valid")
             .removeClass("field-validation-error")


### PR DESCRIPTION
TL;DR: removes error elements in `onReset`.

It's not documented ([question](https://stackoverflow.com/questions/11360925/how-to-clear-jquery-validate-errors), [question](https://stackoverflow.com/questions/2086287/how-to-clear-jquery-validation-error-messages)), but one can generally reset unobtrusive state with `$(form).trigger('reset.unobtrusiveValidation')`:

https://github.com/aspnet/jquery-validation-unobtrusive/blob/74e6ccc7933ac224bdbef84b8dfff6d7ec19f286/src/jquery.validate.unobtrusive.js#L154-L159

This handily includes a call to [jQuery Validator `resetForm()`](https://jqueryvalidation.org/Validator.resetForm/):

https://github.com/aspnet/jquery-validation-unobtrusive/blob/74e6ccc7933ac224bdbef84b8dfff6d7ec19f286/src/jquery.validate.unobtrusive.js#L108

However, it seems like the logic to reset each individual error should account for the fact that it might contain an error message:

https://github.com/aspnet/jquery-validation-unobtrusive/blob/74e6ccc7933ac224bdbef84b8dfff6d7ec19f286/src/jquery.validate.unobtrusive.js#L116-L121

Similarly, resetting `.validation-summary-errors` will leave `<li>`s behind:

https://github.com/aspnet/jquery-validation-unobtrusive/blob/74e6ccc7933ac224bdbef84b8dfff6d7ec19f286/src/jquery.validate.unobtrusive.js#L113-L115