### PR TITLE
Checkbox remote hidden selector fix

### DIFF
--- a/src/jquery.validate.unobtrusive.js
+++ b/src/jquery.validate.unobtrusive.js
@@ -398,7 +398,7 @@
                 var field = $(options.form).find(":input").filter("[name='" + escapeAttributeValue(paramName) + "']");
                 // For checkboxes and radio buttons, only pick up values from checked fields.
                 if (field.is(":checkbox")) {
-                    return field.filter(":checked").val() || field.filter(":hidden").val() || '';
+                    return field.filter(":checked").val() || field.filter("[type='hidden']").val() || '';
                 }
                 else if (field.is(":radio")) {
                     return field.filter(":checked").val() || '';


### PR DESCRIPTION
The filter for hidden checkbox items should target actual type of hidden fields rather than :hidden. As the validation will not run correctly when a element is hidden on the page.

Elements can be considered :hidden for several reasons:
They have a CSS display value of none.
They are form elements with type="hidden".
Their width and height are explicitly set to 0.
An ancestor element is hidden, so the element is not shown on the page.