### PR TITLE
Migrate to 1ES hosted pools

### DIFF
--- a/.vsts-pipelines/templates/default-build.yml
+++ b/.vsts-pipelines/templates/default-build.yml
@@ -81,8 +81,8 @@ jobs:
       vmImage: vs2017-win2016
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
         # This override makes the specified vmImage irrelevant.
-        name: NetCoreInternal-Pool
-        queue: BuildPool.Server.Amd64.VS2019
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals Build.Server.Amd64.VS2019
   variables:
     AgentOsName: ${{ parameters.agentOs }}
     ASPNETCORE_TEST_LOG_MAXPATH: "200" # Keep test log file name length low enough for artifact zipping


### PR DESCRIPTION
We are migrating all repositories to 1ES hosted pools.

Tracking issue: https://github.com/dotnet/core-eng/issues/14276

/cc: @jonfortescue