### PR TITLE
Fixed jQuery deprecations

### DIFF
--- a/src/jquery.validate.unobtrusive.js
+++ b/src/jquery.validate.unobtrusive.js
@@ -55,7 +55,7 @@
     function onError(error, inputElement) {  // 'this' is the form element
         var container = $(this).find("[data-valmsg-for='" + escapeAttributeValue(inputElement[0].name) + "']"),
             replaceAttrValue = container.attr("data-valmsg-replace"),
-            replace = replaceAttrValue ? $.parseJSON(replaceAttrValue) !== false : null;
+            replace = replaceAttrValue ? JSON.parse(replaceAttrValue) !== false : null;
 
         container.removeClass("field-validation-valid").addClass("field-validation-error");
         error.data("unobtrusiveContainer", container);
@@ -88,7 +88,7 @@
 
         if (container) {
             var replaceAttrValue = container.attr("data-valmsg-replace"),
-                replace = replaceAttrValue ? $.parseJSON(replaceAttrValue) : null;
+                replace = replaceAttrValue ? JSON.parse(replaceAttrValue) : null;
 
             container.addClass("field-validation-valid").removeClass("field-validation-error");
             error.removeData("unobtrusiveContainer");
@@ -131,7 +131,7 @@
             defaultOptions = $jQval.unobtrusive.options || {},
             execInContext = function (name, args) {
                 var func = defaultOptions[name];
-                func && $.isFunction(func) && func.apply(form, args);
+                func && typeof func === "function" && func.apply(form, args);
             };
 
         if (!result) {


### PR DESCRIPTION
Replaced usages of `jQuery.parseJSON`: https://github.com/jquery/jquery-migrate/blob/main/warnings.md#parsejson-jqmigrate-jqueryparsejson-is-deprecated-use-jsonparse
Replaced usages of `jQuery.isFunction`: https://github.com/jquery/jquery-migrate/blob/main/warnings.md#isfunction-jqmigrate-jqueryisfunction-is-deprecated