### PR TITLE
Self-Closing Tags with jQuery >=3.5

### DIFF
--- a/src/jquery.validate.unobtrusive.js
+++ b/src/jquery.validate.unobtrusive.js
@@ -78,7 +78,7 @@
             container.addClass("validation-summary-errors").removeClass("validation-summary-valid");
 
             $.each(validator.errorList, function () {
-                $("<li />").html(this.message).appendTo(list);
+                $("<li></li>").html(this.message).appendTo(list);
             });
         }
     }


### PR DESCRIPTION
jQuery 3.5+ migration requests libraries avoid using self-closing tags for tags that may have content unless your page runs in XHTML mode.

https://jquery.com/upgrade-guide/3.5/