### PR TITLE
Fix for potential XSS

### DIFF
--- a/src/jquery.validate.unobtrusive.js
+++ b/src/jquery.validate.unobtrusive.js
@@ -78,7 +78,7 @@
             container.addClass("validation-summary-errors").removeClass("validation-summary-valid");
 
             $.each(validator.errorList, function () {
-                $("<li />").html(this.message).appendTo(list);
+                $("<li />").text(this.message).appendTo(list);
             });
         }
     }


### PR DESCRIPTION
The code contains a potential security issue related to Cross-Site Scripting (XSS). Specifically, the html method in jQuery is used to set the content of a list item `<li /> `without any sanitization of the this.message content, which can lead to XSS if `this.message `contains malicious script.

The code directly inserts this.message into the HTML using html(). If this.message contains any user-generated input, an attacker could inject malicious scripts.

`$("<li />").html(this.message).appendTo(list);`

If an attacker manages to inject a payload like <script>alert('XSS')</script> into this.message, the script would be executed in the context of the user's browser, leading to an XSS attack.

Solution Using text() instead of html()
Using the text() method instead of html() ensures that the content is treated as plain text, thus preventing any HTML from being rendered.

`$("<li />").text(this.message).appendTo(list);`

https://github.com/aspnet/jquery-validation-unobtrusive/issues/168#issue-2424889941