### PR TITLE
Migrate jQuery dependency to jQuery 4.0.0 compatibility, for #183

### DIFF
--- a/Microsoft.jQuery.Unobtrusive.Validation.nuspec
+++ b/Microsoft.jQuery.Unobtrusive.Validation.nuspec
@@ -17,7 +17,7 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>jQuery Unobtrusive</tags>
     <dependencies>
-      <dependency id="jQuery" version="1.8.0" />
+      <dependency id="jQuery" version="4.0.0" />
       <dependency id="jQuery.Validation" version="1.19.3" />
     </dependencies>
   </metadata>

--- a/Microsoft.jQuery.Unobtrusive.Validation.nuspec
+++ b/Microsoft.jQuery.Unobtrusive.Validation.nuspec
@@ -17,7 +17,7 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>jQuery Unobtrusive</tags>
     <dependencies>
-      <dependency id="jQuery" version="4.0.0" />
+      <dependency id="jQuery" version="1.8.0" />
       <dependency id="jQuery.Validation" version="1.19.3" />
     </dependencies>
   </metadata>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.0",
       "license": "https://aka.ms/jqueryunobtrusivelicense",
       "dependencies": {
-        "jquery": "^3.6.0",
+        "jquery": "^4.0.0",
         "jquery-validation": ">=1.19"
       },
       "devDependencies": {
@@ -2329,9 +2329,9 @@
       }
     },
     "node_modules/jquery": {
-      "version": "3.7.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha1-CD75iSfJpqdNBaavAoBlZtFidN4=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
+      "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
       "license": "MIT",
       "peer": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.0",
       "license": "https://aka.ms/jqueryunobtrusivelicense",
       "dependencies": {
-        "jquery": "^4.0.0",
+        "jquery": "^3.6.0 || ^4.0.0",
         "jquery-validation": ">=1.19"
       },
       "devDependencies": {
@@ -2329,9 +2329,9 @@
       }
     },
     "node_modules/jquery": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
-      "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
+      "version": "3.7.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha1-CD75iSfJpqdNBaavAoBlZtFidN4=",
       "license": "MIT",
       "peer": true
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dist/jquery.validate.unobtrusive.min.js"
   ],
   "dependencies": {
-    "jquery": "^3.6.0",
+    "jquery": "^4.0.0",
     "jquery-validation": ">=1.19"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dist/jquery.validate.unobtrusive.min.js"
   ],
   "dependencies": {
-    "jquery": "^4.0.0",
+    "jquery": "^3.6.0 || ^4.0.0",
     "jquery-validation": ">=1.19"
   },
   "devDependencies": {

--- a/src/jquery.validate.unobtrusive.js
+++ b/src/jquery.validate.unobtrusive.js
@@ -127,7 +127,7 @@
     function validationInfo(form) {
         var $form = $(form),
             result = $form.data(data_validation),
-            onResetProxy = $.proxy(onReset, form),
+            onResetProxy = onReset.bind(form),
             defaultOptions = $jQval.unobtrusive.options || {},
             execInContext = function (name, args) {
                 var func = defaultOptions[name];


### PR DESCRIPTION
This pull request updates the `jquery.validate.unobtrusive` package to support jQuery 4.0.0 and makes a small improvement to the event handler binding in the JavaScript source. The main focus is ensuring compatibility with the latest jQuery release.

**Dependency updates:**

* Updated the required jQuery version to 4.0.0 in both `Microsoft.jQuery.Unobtrusive.Validation.nuspec` and `package.json`. [[1]](diffhunk://#diff-98f324d9ca8025ff12aa8f169e1e41458c52badea42e9d4c12377825c8419a71L20-R20) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L28-R28)

**Code compatibility:**

* Replaced usage of `$.proxy` with `Function.prototype.bind` for the `onResetProxy` event handler in `src/jquery.validate.unobtrusive.js` to align with modern JavaScript practices and compatibility with jQuery 4.0.0.

Closes https://github.com/aspnet/jquery-validation-unobtrusive/issues/183