### PR TITLE
Update brace-expansion to address CVE-2026-69152

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -451,16 +451,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha1-apxsJo+FtTlZ7FJ66v4PcwAlju8=",
+      "version": "5.0.9",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -1634,9 +1634,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
+      "version": "1.1.18",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Updates the vulnerable `brace-expansion` dependency lines:

- 1.1.12 to 1.1.18
- 5.0.3 to 5.0.9

These versions contain the fix for [CVE-2026-69152 / GHSA-rgw5-rvv9-x895](https://github.com/juliangruber/brace-expansion/security/advisories/GHSA-rgw5-rvv9-x895). Both patched packages were requested through the `dotnet-public-npm` Azure Artifacts feed configured in `.npmrc`, and the lockfile resolves their tarballs from that feed.

Validation:
- `npm ci`
- `npm ls brace-expansion --all`
- `npm audit` no longer reports a `brace-expansion` vulnerability